### PR TITLE
Rename project templates field types

### DIFF
--- a/app/javascript/controllers/overlay_controller.js
+++ b/app/javascript/controllers/overlay_controller.js
@@ -137,20 +137,4 @@ export default class extends Controller {
 
     this.close(event);
   }
-
-  goBack(event) {
-    if (event) event.preventDefault();
-    this.returnToList();
-  }
-
-  returnToList() {
-    this.containerTarget.removeAttribute("src");
-    this.containerTarget.removeAttribute("complete");
-    
-    if (this.initialContent) {
-      this.containerTarget.innerHTML = this.initialContent;
-    } else {
-      this.containerTarget.innerHTML = "";
-    }
-  }
 }

--- a/app/javascript/project_template_fields.js
+++ b/app/javascript/project_template_fields.js
@@ -10,10 +10,10 @@ document.addEventListener("turbo:load", function () {
 
   // Field type options from Rails enum
   const fieldTypeOptions = [
-    { value: "shorttext", label: "Shorttext" },
-    { value: "textarea", label: "Textarea" },
-    { value: "dropdown", label: "Dropdown" },
-    { value: "radio", label: "Radio" },
+    { value: "shorttext", label: "Short Text" },
+    { value: "textarea", label: "Paragraph" },
+    { value: "dropdown", label: "Dropdown Selection" },
+    { value: "radio", label: "Selection" },
   ];
 
   const applicableToOptions = [

--- a/app/models/project_template_field.rb
+++ b/app/models/project_template_field.rb
@@ -20,6 +20,10 @@ class ProjectTemplateField < ApplicationRecord
     'radio' => 'Selection'
   }.freeze
 
+  def field_type_label
+    FIELD_TYPE_LABELS[field_type] || field_type.to_s.humanize
+  end
+
   def option_list
     options.to_s.gsub(/[\[\]"]/, '').split(',').map(&:strip)
   end

--- a/app/models/project_template_field.rb
+++ b/app/models/project_template_field.rb
@@ -13,6 +13,13 @@ class ProjectTemplateField < ApplicationRecord
   before_validation :force_title_required
   before_destroy :cannot_delete_if_in_use
 
+  FIELD_TYPE_LABELS = {
+    'shorttext' => 'Short Text',
+    'textarea' => 'Paragraph',
+    'dropdown' => 'Dropdown Selection',
+    'radio' => 'Selection'
+  }.freeze
+
   def option_list
     options.to_s.gsub(/[\[\]"]/, '').split(',').map(&:strip)
   end

--- a/app/views/courses/_copy_course_details.html.erb
+++ b/app/views/courses/_copy_course_details.html.erb
@@ -133,7 +133,7 @@
                     <%= field.label %>
                   </span>
                   <span class="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700 ring-1 ring-inset ring-indigo-700/10">
-                    <%= field.field_type.humanize %>
+                    <%= field.field_type_label %>
                   </span>
                 </div>
 

--- a/app/views/courses/_copy_course_details.html.erb
+++ b/app/views/courses/_copy_course_details.html.erb
@@ -6,7 +6,7 @@
     <div class="flex-none mb-6 flex items-center justify-between">
       <h3 class="text-2xl font-bold text-gray-600">Select Fields to Copy: <%= source.course_name %></h3>
       <button type="button" 
-              data-action="click->overlay#goBack" 
+              data-action="click->overlay#returnToList" 
               class="text-sm text-blue-600 hover:underline">
         ← Back
       </button>

--- a/app/views/project_templates/_field_row.html.erb
+++ b/app/views/project_templates/_field_row.html.erb
@@ -84,7 +84,7 @@
     <%= field_form.select :field_type,
                       options_for_select(
                         ProjectTemplateField.field_types.keys.map do |k|
-                          [k.humanize, k]
+                          [ProjectTemplateField::FIELD_TYPE_LABELS[k], k]
                         end,
                         field_form.object.field_type,
                       ),

--- a/app/views/project_templates/_new_field.html.erb
+++ b/app/views/project_templates/_new_field.html.erb
@@ -81,7 +81,9 @@
       >
         <option value="">Select field type</option>
         <% ProjectTemplateField.field_types.keys.each do |key| %>
-          <option value="<%= key %>"><%= key.humanize %></option>
+          <option value="<%= key %>">
+            <%= field.field_type_label %>
+          </option>
         <% end %>
       </select>
     </div>

--- a/app/views/project_templates/edit.html.erb
+++ b/app/views/project_templates/edit.html.erb
@@ -57,7 +57,7 @@
                 Field Label
               </th>
               <th scope="col" class="px-6 py-5 text-left text-[11px] font-bold text-gray-500 uppercase tracking-widest w-[20%]">
-                Hint Text
+                Description
               </th>
               <th scope="col" class="px-6 py-5 text-left text-[11px] font-bold text-gray-500 uppercase tracking-widest w-[13%]">
                 Type
@@ -69,7 +69,7 @@
                 Options
               </th>
               <th scope="col" class="px-2 py-5 text-center text-[11px] font-bold text-gray-500 uppercase tracking-widest w-[7%]">
-                Req.
+                Required
               </th>
               <th scope="col" class="px-2 py-5 text-center text-[10px] font-bold text-gray-500 uppercase tracking-normal leading-4 w-[8%]">
                 Editable <br> Post-Approval

--- a/app/views/topics/_copy_topic_details.html.erb
+++ b/app/views/topics/_copy_topic_details.html.erb
@@ -40,7 +40,7 @@
                 </span>
                 
                 <span class="inline-flex items-center rounded-full bg-indigo-50 px-2.5 py-0.5 text-[11px] font-medium text-indigo-600 ring-1 ring-inset ring-indigo-200">
-                  <%= field.field_type.humanize %>
+                  <%= field.field_type_label %>
                 </span>
               </div>
 


### PR DESCRIPTION
## Changelog

1.  Update terms in projects templates setup page for easier understanding:
      1. Shorttext → Short Text
      2. Textarea → Paragraph
      3. Dropdown → Dropdown Selection
      4. Radio -> Selection
      5. Hint Text → Description
2. Remove redundant code
